### PR TITLE
Fix terminal cursor not showing after app exit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -64,6 +64,7 @@ pub struct App {
     pub dir_list_state: ListState,
     pub confirm_action: Option<String>,
     pub scan_results: ScanResults,
+    pub should_exit: bool,
 }
 
 impl App {
@@ -83,6 +84,7 @@ impl App {
             dir_list_state: ListState::default(),
             confirm_action: None,
             scan_results: ScanResults::default(),
+            should_exit: false,
         }
     }
 
@@ -194,7 +196,7 @@ impl App {
     pub fn handle_key_event(&mut self, key: KeyEvent) {
         if let AppState::DeletionComplete = self.state {
             match key.code {
-                KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => std::process::exit(0),
+                KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => self.should_exit = true,
                 _ => {}
             }
             return;
@@ -223,7 +225,7 @@ impl App {
 
         match self.state {
             AppState::Scanning => match key.code {
-                KeyCode::Char('q') => std::process::exit(0),
+                KeyCode::Char('q') => self.should_exit = true,
                 KeyCode::Esc => {
                     self.confirm_action = Some("Stop the current scan".to_string());
                 }
@@ -233,7 +235,7 @@ impl App {
                 // Ignore key events while stopping
             }
             AppState::ScanComplete | AppState::DeletionComplete => match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => std::process::exit(0),
+                KeyCode::Char('q') | KeyCode::Esc => self.should_exit = true,
                 // Handle list navigation with clamped indices
                 KeyCode::Down => {
                     // Handle list navigation down with proper bounds checking

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         terminal.draw(|f| ui::draw(f, &mut app))?;
 
+        // Check if we should exit
+        if app.should_exit {
+            break;
+        }
+
         // Handle scan updates
         if let Some(receiver) = &app.scan_receiver {
             if let Ok(update) = receiver.try_recv() {


### PR DESCRIPTION
- Add should_exit flag to App struct for graceful shutdown
- Replace std::process::exit(0) calls with flag setting
- Update main loop to check exit flag and break gracefully
- Ensures terminal cleanup code runs properly on exit